### PR TITLE
introduce debug module, use debug module in DMXOutput

### DIFF
--- a/lib/transport/DmxOutput.js
+++ b/lib/transport/DmxOutput.js
@@ -1,3 +1,5 @@
+import debug from 'debug';
+
 /**
  * Encapsulates the DMX-buffers to be used and handles sending of data to the
  * driver.
@@ -17,6 +19,7 @@ export default class DmxOutput {
     this.frameCount = 0;
     this.frameInterval = 0;
     this.isRunning = false;
+    this.debug = debug('fivetwelve:dmxoutput');
 
     this.dmxBuffers = [];
     this.dmxFrameCallbacks = [];
@@ -143,7 +146,7 @@ export default class DmxOutput {
       }
 
       if (frameDuration > frameInterval) {
-        console.error(`skipped frame ${this.frameCount}`);
+        this.debug(`skipped frame ${this.frameCount}`)
       }
 
       // the `frameDuration % frameInterval` makes sure that a skipped frame

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "array.from": "^0.2.0",
     "color-convert": "^0.6.0",
+    "debug": "^2.6.8",
     "object-assign": "^4.0.1",
     "parse-color": "^1.0.0"
   },


### PR DESCRIPTION
hi,
i noticed that the `next` version of fivetwelve dumps notices into the console. 
in the past i made very good experiences with the usage of the `debug` module so i decide to propose the introduction of this module.
the debug module can also be useful at other places in the fivetwelve module.

let me hear your thoughts! :)